### PR TITLE
Fix JSON parse error on invalid username playlist request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+*.swp
+
 #webstorm
 .idea
 

--- a/README.md
+++ b/README.md
@@ -1,31 +1,57 @@
 # Hypem NodeJS Wrapper
 
-This is an unofficial nodejs wrapper around the (undocumented? -- I couldn't find anything) **Hype Machine** (http://hypem.com) public API. It is a port of [@JackCA's](https://github.com/JackCA/) implementation of a [Ruby gem](https://github.com/JackCA/hypem/) of the api. Note that there are some differences.
+This is an unofficial nodejs wrapper around the (undocumented? -- I couldn't
+find anything) **Hype Machine** (http://hypem.com) public API. It is a port
+of [@JackCA's](https://github.com/JackCA/) implementation of a 
+[Ruby gem](https://github.com/JackCA/hypem/) of the API. Note that there 
+are some differences.
 
 ## Installation
 `npm install node-hypem`
 
 ## Usage
+
 For general usage:
+
 ```javascript
 var Hypem = require("node-hypem");
 ```
-The `Hypem` object has both a `Playlist` object, which can grab information about the various song lists on the hypem website, and a `User` object which returns playlists specific to the provided user.
+The `Hypem` object has both a `Playlist` object, which can grab information
+about the various song lists on the hypem website, and a `User` object
+which returns playlists specific to the provided user.
 
 All callbacks are of the form `function(err, response)`.
-###Playlist
-Playlist functions return json playlist data. All parameters except for `filter` are required (which defaults to `all`). As the api does not provide cursors, paging may have concurrency issues if you don't monitor changes.
+
+### Playlist
+
+Playlist functions return JSON playlist data. All parameters except for
+`filter` are required (which defaults to `all`). As the API does not
+provide cursors, paging may have concurrency issues if you don't monitor
+changes.
+
 ```javascript
-Hypem.playlist.popular(filter, page_number, callback) //Valid arguments for filter are: all, lastweek, remix, noremix, artists, twitter
-Hypem.playlist.latest(filter, page_number, callback) //Valid arguments for filter are: all, remix, noremix, us
+// Filter options: "all", "lastweek", "remix", "noremix", "artists", "twitter"
+Hypem.playlist.popular(filter, page_number, callback)
+
+// Filter options: "all", "remix", "noremix", "fresh", or country code 
+// ("ca", "us", "fr", etc) 
+Hypem.playlist.latest(filter, page_number, callback)
+ 
 Hypem.playlist.artist(artist_name, page_number, callback)
-Hypem.playlist.blog(blog_id, page_number, callback) //note that you need the blog id, not it's name
+
+// "blog_id" is the siteid (number), not it's name
+Hypem.playlist.blog(blog_id, page_number, callback) 
+
 Hypem.playlist.search(search_query, page_number, callback)
-Hypem.playlist.tags([tag_array], page_number, callback) //API warns against using too many tags
+
+// API warns against using too many tags
+Hypem.playlist.tags([tag_array], page_number, callback)
 ```
 
-###User
-`Hypem.user(user_name)` creates a new user object. If the username is invalid, specific user requests will return either `[]` or `null` depending on the api call.
+### User
+
+`Hypem.user(user_name)` creates a new user object. If the username is invalid,
+`null` is returned.
 
 The following requests return playlists of tracks specific to the user.
 ```javascript
@@ -38,8 +64,14 @@ Hypem.user(user_name).people_obsessed(page_number, callback)
 ```
 
 Additionally, the following user specific requests are also available:
+
 ```javascript
-Hypem.user(user_name).get_profile(page_number, callback)
-Hypem.user(user_name).get_friends(page_number, callback)
-Hypem.user(user_name).get_favorite_blogs(page_number, callback)
+// Returns null on invalid username
+Hypem.user(user_name).get_profile(callback)
+
+// Returns [ ] on invalid username/no friends
+Hypem.user(user_name).get_friends(callback)
+
+// Returns null on invalid username/no favorite blogs
+Hypem.user(user_name).get_favorite_blogs(callback)
 ```

--- a/lib/hypem.js
+++ b/lib/hypem.js
@@ -76,12 +76,22 @@ var https = require("https");
                 requestResponse += response;
             });
             res.on("end", function() {
-                cb(null, JSON.parse(requestResponse));
+                if (res.statusCode === 404) {
+                    cb(new Error("Not Found"), null);
+                }
+                else {
+                    // For safety, do try-catch 
+                    try {
+                        cb(null, JSON.parse(requestResponse));
+                    } catch (err) {
+                        cb(new Error("Invalid JSON"), null);
+                    }
+                }
             });
         });
         req.end();
-        req.on("error", function(e) {
-            cb(err);
+        req.on("error", function(err) {
+            cb(err, null);
         });
     };
 


### PR DESCRIPTION
- On invalid username, any of the user based playlist requests (`hypem.user().loved`, etc) throws exception as 404 page is returned by hypem, not JSON, thus parse JSON line fails. Now check for 404, and do try-catch for JSON parse for safety
- Small fixes/updates in README.md and 80 character line stop
- Addition to .gitignore
